### PR TITLE
fix: add auth state to local storage

### DIFF
--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,5 +1,5 @@
 import create, { SetState } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { devtools, persist } from 'zustand/middleware';
 import { AuthState, AuthStore } from 'types';
 import { login, signup, logout } from 'features/auth/api';
 
@@ -49,4 +49,4 @@ const authStore = (set: SetState<AuthStore>): AuthStore => ({
   },
 });
 
-export const useAuth = create(devtools(authStore));
+export const useAuth = create(devtools(persist(authStore, { name: 'auth-local-storage' })));


### PR DESCRIPTION
Closes #5 
Saving the auth state in the local storage so that the initial authentication retrieval would be faster.